### PR TITLE
Allows callable to stop the loop throwing a StopSSEException

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ source.addEventListener('news', function(event) {
 ```PHP
 use Hhxsv5\SSE\Event;
 use Hhxsv5\SSE\SSE;
+use Hhxsv5\SSE\StopSSEException;
 
 // PHP-FPM SSE Example: push messages to client
 
@@ -58,6 +59,10 @@ $callback = function () {
     if (empty($news)) {
         return false; // Return false if no new messages
     }
+    $shouldStop = false;
+    if ($shouldStop) {
+        throw new StopSSEException();
+    }
     return json_encode(compact('news'));
     // return ['id' => uniqid(), 'data' => json_encode(compact('news'))]; // Custom event Id
 };
@@ -70,6 +75,7 @@ $callback = function () {
 ```PHP
 use Hhxsv5\SSE\SSE;
 use Hhxsv5\SSE\Event;
+use Hhxsv5\SSE\StopSSEException;
 
 // Action method in controller
 public function getNewsStream()
@@ -85,6 +91,10 @@ public function getNewsStream()
             $news = [['id' => $id, 'title' => 'title ' . $id, 'content' => 'content ' . $id]]; // Get news from database or service.
             if (empty($news)) {
                 return false; // Return false if no new messages
+            }
+            $shouldStop = false;
+            if ($shouldStop) {
+                throw new StopSSEException();
             }
             return json_encode(compact('news'));
             // return ['id' => uniqid(), 'data' => json_encode(compact('news'))]; // Custom event Id
@@ -105,6 +115,7 @@ use Hhxsv5\SSE\SSESwoole;
 use Swoole\Http\Request;
 use Swoole\Http\Response;
 use Swoole\Http\Server;
+use Hhxsv5\SSE\StopSSEException;
 
 // Swoole SSE Example: push messages to client
 
@@ -132,6 +143,10 @@ $server->on('Request', function (Request $request, Response $response) use ($ser
         $news = [['id' => $id, 'title' => 'title ' . $id, 'content' => 'content ' . $id]]; // Get news from database or service.
         if (empty($news)) {
             return false; // Return false if no new messages
+        }
+        $shouldStop = false;
+        if ($shouldStop) {
+            throw new StopSSEException();
         }
         return json_encode(compact('news'));
         // return ['id' => uniqid(), 'data' => json_encode(compact('news'))]; // Custom event Id

--- a/examples/sse-swoole.php
+++ b/examples/sse-swoole.php
@@ -3,6 +3,7 @@ include '../vendor/autoload.php';
 
 use Hhxsv5\SSE\Event;
 use Hhxsv5\SSE\SSESwoole;
+use Hhxsv5\SSE\StopSSEException;
 use Swoole\Http\Request;
 use Swoole\Http\Response;
 use Swoole\Http\Server;
@@ -33,6 +34,10 @@ $server->on('Request', function (Request $request, Response $response) use ($ser
         $news = [['id' => $id, 'title' => 'title ' . $id, 'content' => 'content ' . $id]]; // Get news from database or service.
         if (empty($news)) {
             return false; // Return false if no new messages
+        }
+        $shouldStop = false; // Stop if something happens or to clear connection, browser will retry
+        if ($shouldStop) {
+            throw new StopSSEException();
         }
         return json_encode(compact('news'));
         // return ['id' => uniqid(), 'data' => json_encode(compact('news'))]; // Custom event Id

--- a/examples/sse.php
+++ b/examples/sse.php
@@ -3,6 +3,7 @@ include '../vendor/autoload.php';
 
 use Hhxsv5\SSE\Event;
 use Hhxsv5\SSE\SSE;
+use Hhxsv5\SSE\StopSSEException;
 
 // PHP-FPM SSE Example: push messages to client
 
@@ -16,6 +17,10 @@ $callback = function () {
     $news = [['id' => $id, 'title' => 'title ' . $id, 'content' => 'content ' . $id]]; // Get news from database or service.
     if (empty($news)) {
         return false; // Return false if no new messages
+    }
+    $shouldStop = false; // Stop if something happens or to clear connection, browser will retry
+    if ($shouldStop) {
+        throw new StopSSEException();
     }
     return json_encode(compact('news'));
     // return ['id' => uniqid(), 'data' => json_encode(compact('news'))]; // Custom event Id

--- a/src/Event.php
+++ b/src/Event.php
@@ -30,10 +30,16 @@ class Event
     protected $comment;
 
     /**
-     * @var callable The callback to get event data
+     * @var callable The callback to get event data. Throw a {@see StopSSEException} to stop the execution, browser will retry after {@see $retry}
      */
     protected $callback;
 
+    /**
+     * Event constructor.
+     * @param callable $callback {@see Event::$callback}
+     * @param string   $event    {@see Event::$event}
+     * @param int      $retry    {@see Event::$retry}
+     */
     public function __construct(callable $callback, $event = '', $retry = 5000)
     {
         $this->callback = $callback;
@@ -47,6 +53,7 @@ class Event
     /**
      * Fill the event data & id
      * @return $this
+     * @throws StopSSEException
      */
     public function fill()
     {

--- a/src/SSE.php
+++ b/src/SSE.php
@@ -13,12 +13,16 @@ class SSE
 
     /**
      * Start SSE Server
-     * @param int $interval
+     * @param int $interval in seconds
      */
     public function start($interval = 3)
     {
         while (true) {
-            echo $this->event->fill();
+            try {
+                echo $this->event->fill();
+            } catch (StopSSEException $e) {
+                return;
+            }
             ob_flush();
             flush();
             // if the connection has been closed by the client we better exit the loop
@@ -28,5 +32,4 @@ class SSE
             sleep($interval);
         }
     }
-
 }

--- a/src/SSESwoole.php
+++ b/src/SSESwoole.php
@@ -25,7 +25,12 @@ class SSESwoole extends SSE
     public function start($interval = 3)
     {
         while (true) {
-            $success = $this->response->write($this->event->fill());
+            try {
+                $success = $this->response->write($this->event->fill());
+            } catch (StopSSEException $e) {
+                $this->response->end();
+                return;
+            }
             if (!$success) {
                 $this->response->end();
                 return;

--- a/src/StopSSEException.php
+++ b/src/StopSSEException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Hhxsv5\SSE;
+
+class StopSSEException extends \Exception
+{
+}


### PR DESCRIPTION
This allows the callable to stop the loop.

We also may use a return value or a callable parameter passed to the callback to implement this, but the exception was the easiest to implement